### PR TITLE
Dialogue and Save System Integration

### DIFF
--- a/Assets/Dialogues/Test/TestDialogueGroup.asset
+++ b/Assets/Dialogues/Test/TestDialogueGroup.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c344bf28d4ddb634ea370fb8edc56ffc, type: 3}
+  m_Name: TestDialogueGroup
+  m_EditorClassIdentifier: 
+  _dialogues:
+  - {fileID: 11400000, guid: 479ccedc3cf7139409787b98714d6d95, type: 2}
+  - {fileID: 11400000, guid: 16348b85c526171458b8f2f26b3c8749, type: 2}
+  - {fileID: 11400000, guid: 097dd3b1b240eba4f8e3390685398cfc, type: 2}

--- a/Assets/Dialogues/Test/TestDialogueGroup.asset.meta
+++ b/Assets/Dialogues/Test/TestDialogueGroup.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b9d3c4f6a4f1dc74db46ba1b34e6c08d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Development/DialoguesTest.unity
+++ b/Assets/Scenes/Development/DialoguesTest.unity
@@ -568,6 +568,63 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1482835330
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3855088386138911170, guid: 54d993e39225ea2418fb7c2a01ac4570, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3855088386138911170, guid: 54d993e39225ea2418fb7c2a01ac4570, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3855088386138911170, guid: 54d993e39225ea2418fb7c2a01ac4570, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3855088386138911170, guid: 54d993e39225ea2418fb7c2a01ac4570, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3855088386138911170, guid: 54d993e39225ea2418fb7c2a01ac4570, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3855088386138911170, guid: 54d993e39225ea2418fb7c2a01ac4570, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3855088386138911170, guid: 54d993e39225ea2418fb7c2a01ac4570, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3855088386138911170, guid: 54d993e39225ea2418fb7c2a01ac4570, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3855088386138911170, guid: 54d993e39225ea2418fb7c2a01ac4570, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3855088386138911170, guid: 54d993e39225ea2418fb7c2a01ac4570, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5462522973888765915, guid: 54d993e39225ea2418fb7c2a01ac4570, type: 3}
+      propertyPath: m_Name
+      value: SaveSystem
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 54d993e39225ea2418fb7c2a01ac4570, type: 3}
 --- !u!1 &1610916996
 GameObject:
   m_ObjectHideFlags: 0
@@ -1130,6 +1187,7 @@ GameObject:
   - component: {fileID: 2130008934}
   - component: {fileID: 2130008933}
   - component: {fileID: 2130008932}
+  - component: {fileID: 2130008937}
   - component: {fileID: 2130008931}
   m_Layer: 0
   m_Name: Actor
@@ -1289,6 +1347,20 @@ Transform:
   - {fileID: 1877490629}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2130008937
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2130008930}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b807ad93bd61d74e9510bcc3e0a3ed9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _id: test_dialogue_actor
+  _group: {fileID: 11400000, guid: b9d3c4f6a4f1dc74db46ba1b34e6c08d, type: 2}
 --- !u!1001 &3415967135103170412
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1402,4 +1474,5 @@ SceneRoots:
   - {fileID: 2130008936}
   - {fileID: 681311118}
   - {fileID: 3415967135103170412}
+  - {fileID: 1482835330}
   - {fileID: 933492194}

--- a/Assets/Scripts/Dialogue/Control/DialogueActor.cs
+++ b/Assets/Scripts/Dialogue/Control/DialogueActor.cs
@@ -8,9 +8,9 @@ using UnityEngine;
 /// the dialogue's initiation. Also, it allows additional components
 /// to perform custom behaviour on dialogue events (will be implemented in future).
 /// </remarks>
+[DisallowMultipleComponent]
 public class DialogueActor : MonoBehaviour, IDialogueListener
 {
-	// TODO: integrate with the save system
 	// TODO: add dialogue events
 
 	// A node that will be played next
@@ -23,9 +23,27 @@ public class DialogueActor : MonoBehaviour, IDialogueListener
 	[SerializeField]
 	private DialoguePlayer _dialoguePlayer;
 
+	/// <summary>
+	/// Gets a node that will be played when initiating the dialogue.
+	/// </summary>
+	public DialogueNode nextNode => _nextNode;
+
 	private void Start()
 	{
 		_nextNode = _firstNode;
+	}
+
+	/// <summary>
+	/// Sets the next node to a specific value.
+	/// </summary>
+	/// <param name="node">The node to be played next.</param>
+	/// <exception cref="System.ArgumentNullException" />
+	public void SetNextNode(DialogueNode node)
+	{
+		if (!node)
+			throw new System.ArgumentNullException(nameof(node));
+
+		_nextNode = node;
 	}
 
 	/// <summary>

--- a/Assets/Scripts/Dialogue/Control/DialogueActor.cs
+++ b/Assets/Scripts/Dialogue/Control/DialogueActor.cs
@@ -30,7 +30,7 @@ public class DialogueActor : MonoBehaviour, IDialogueListener
 
 	private void Start()
 	{
-		_nextNode = _firstNode;
+		if (!_nextNode) _nextNode = _firstNode;
 	}
 
 	/// <summary>

--- a/Assets/Scripts/Dialogue/Data/DialogueGroup.cs
+++ b/Assets/Scripts/Dialogue/Data/DialogueGroup.cs
@@ -12,6 +12,8 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "Dialogue Group", menuName = "Dialogue/Group")]
 public class DialogueGroup : ScriptableObject
 {
+	private IReadOnlyDictionary<string, DialogueNode> _nameToDialogue = null;
+
 	[SerializeField]
 	[Tooltip("Dialogue nodes that were found. " +
 		"Don't change this list manually because you will lose changes.")]
@@ -21,6 +23,20 @@ public class DialogueGroup : ScriptableObject
 	/// Gets a collection of dialogue nodes associated with this group.
 	/// </summary>
 	public IReadOnlyList<DialogueNode> dialogues => _dialogues;
+
+	/// <summary>
+	/// Gets a readonly dictionary that maps a name to the dialogue node.
+	/// </summary>
+	public IReadOnlyDictionary<string, DialogueNode> nameToDialogue
+	{
+		get
+		{
+			if (_nameToDialogue != null) return _nameToDialogue;
+
+			_nameToDialogue = _dialogues.ToDictionary(x => x.name, x => x);
+			return _nameToDialogue;
+		}
+	}
 
 #if UNITY_EDITOR
 	private void OnValidate()

--- a/Assets/Scripts/Dialogue/Data/DialogueGroup.cs
+++ b/Assets/Scripts/Dialogue/Data/DialogueGroup.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// A scriptable object which holds all dialogue nodes in the
+/// same folder (including subfolders) it's located.
+/// </summary>
+[CreateAssetMenu(fileName = "Dialogue Group", menuName = "Dialogue/Group")]
+public class DialogueGroup : ScriptableObject
+{
+	[SerializeField]
+	[Tooltip("Dialogue nodes that were found. " +
+		"Don't change this list manually because you will lose changes.")]
+	private DialogueNode[] _dialogues = { };
+
+	/// <summary>
+	/// Gets a collection of dialogue nodes associated with this group.
+	/// </summary>
+	public IReadOnlyList<DialogueNode> dialogues => _dialogues;
+
+#if UNITY_EDITOR
+	public void LoadNodes()
+	{
+		string assetPath = AssetDatabase.GetAssetPath(this);
+		string assetDirectory = Path.GetDirectoryName(assetPath);
+
+		List<DialogueNode> loadedNodes = new();
+		var files = Directory.GetFiles(assetDirectory, "*.asset", SearchOption.AllDirectories);
+		foreach (var file in files)
+		{
+			var node = AssetDatabase.LoadAssetAtPath<DialogueNode>(file);
+			if (node == null) continue;
+
+			loadedNodes.Add(node);
+		}
+		var newNodes = loadedNodes.ToArray();
+		// Check if the array was actually updated
+		if (!ArrayUtility.ArrayEquals(_dialogues, newNodes))
+		{
+			EditorUtility.SetDirty(this);
+			_dialogues = newNodes;
+		}
+	}
+#endif
+}

--- a/Assets/Scripts/Dialogue/Data/DialogueGroup.cs.meta
+++ b/Assets/Scripts/Dialogue/Data/DialogueGroup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c344bf28d4ddb634ea370fb8edc56ffc

--- a/Assets/Scripts/Dialogue/Saving.meta
+++ b/Assets/Scripts/Dialogue/Saving.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ca89abdc7fcec642b78f1319c92cc8d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/Saving/DialogueActorSaver.cs
+++ b/Assets/Scripts/Dialogue/Saving/DialogueActorSaver.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+/// <summary>
+/// A component that allows to save the <see cref="DialogueActor" /> state.
+/// </summary>
+[DisallowMultipleComponent]
+[RequireComponent(typeof(DialogueActor))]
+public class DialogueActorSaver : SavableComponent<DialogueSaveData>
+{
+	private DialogueActor _actor;
+	private DialogueActor actor => _actor ? _actor : _actor = GetComponent<DialogueActor>();
+
+	[SerializeField]
+	[Tooltip("A group of dialogue nodes that the actor uses.")]
+	private DialogueGroup _group;
+
+	protected override DialogueSaveData fallbackData => new();
+
+	protected override void Validate(DialogueSaveData data)
+	{
+		if (string.IsNullOrEmpty(data.nextNodeName) || !_group) return;
+
+		if (!_group.nameToDialogue.ContainsKey(data.nextNodeName))
+		{
+			Debug.LogWarning($"Couldn't find a dialogue node with \"{data.nextNodeName}\" name.", gameObject);
+			data.nextNodeName = null;
+		}
+	}
+
+	protected override void OnLoad()
+	{
+		if (!_group)
+		{
+			Debug.LogError($"The \"{gameObject.name}\" has no dialogue group assigned to it.", gameObject);
+			return;
+		}
+
+		if (!string.IsNullOrEmpty(data.nextNodeName) &&
+			_group.nameToDialogue.TryGetValue(data.nextNodeName, out var node))
+		{
+			actor.SetNextNode(node);
+		}
+	}
+
+	protected override void OnSave()
+	{
+		data.nextNodeName = actor.nextNode.name;
+	}
+}

--- a/Assets/Scripts/Dialogue/Saving/DialogueActorSaver.cs.meta
+++ b/Assets/Scripts/Dialogue/Saving/DialogueActorSaver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9b807ad93bd61d74e9510bcc3e0a3ed9

--- a/Assets/Scripts/Dialogue/Saving/DialogueSaveData.cs
+++ b/Assets/Scripts/Dialogue/Saving/DialogueSaveData.cs
@@ -1,0 +1,12 @@
+/// <summary>
+/// Data structure that hold information about the <see cref="DialogueActor" />
+/// state.
+/// </summary>
+[System.Serializable]
+public class DialogueSaveData
+{
+	/// <summary>
+	/// A name of the next node that should be played.
+	/// </summary>
+	public string nextNodeName { get; set; }
+}

--- a/Assets/Scripts/Dialogue/Saving/DialogueSaveData.cs.meta
+++ b/Assets/Scripts/Dialogue/Saving/DialogueSaveData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 19b9240155feb5347bcee3a8ba0b4181

--- a/Assets/Scripts/Editor/Dialogue.meta
+++ b/Assets/Scripts/Editor/Dialogue.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 746eb9928b777634ca7f7de56e2b9494
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/Dialogue/AutoDialogueGroupLoader.cs
+++ b/Assets/Scripts/Editor/Dialogue/AutoDialogueGroupLoader.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using UnityEditor;
+
+/// <summary>
+/// A class which automatically populates dialogue groups with
+/// dialogues located in the same root folder.
+/// </summary>
+public class AutoDialogueLoader : AssetPostprocessor
+{
+	// Flag that prevents infinite loops
+	private static bool _isProcessing = false;
+
+	private static bool ContainsPath(string[] array, string path)
+	{
+		foreach (var item in array)
+		{
+			if (item.ToLower().Contains(path))
+				return true;
+		}
+		return false;
+	}
+
+	private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
+	{
+		if (_isProcessing) return;
+		_isProcessing = true;
+
+		var collections = AssetDatabase.FindAssets($"t:{nameof(DialogueGroup)}");
+		bool save = false;
+		foreach (string guid in collections)
+		{
+			string path = AssetDatabase.GUIDToAssetPath(guid);
+			string directory = Path.GetDirectoryName(path).ToLower().Replace('\\', '/');
+			if (ContainsPath(importedAssets, directory) || ContainsPath(deletedAssets, directory) ||
+				ContainsPath(movedAssets, directory) || ContainsPath(movedFromAssetPaths, directory))
+			{
+				var collection = AssetDatabase.LoadAssetAtPath<DialogueGroup>(path);
+				collection.LoadNodes();
+				save = true;
+			}
+		}
+		if (save) AssetDatabase.SaveAssets();
+
+		_isProcessing = false;
+	}
+}

--- a/Assets/Scripts/Editor/Dialogue/AutoDialogueGroupLoader.cs.meta
+++ b/Assets/Scripts/Editor/Dialogue/AutoDialogueGroupLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef61b3e86b8f4e14b932997e4cc636ef

--- a/Assets/Scripts/Editor/Dialogue/DialogueGroupEditor.cs
+++ b/Assets/Scripts/Editor/Dialogue/DialogueGroupEditor.cs
@@ -1,0 +1,20 @@
+using UnityEditor;
+using UnityEngine;
+
+[CustomEditor(typeof(DialogueGroup))]
+public class DialogueGroupEditor : Editor
+{
+	public override void OnInspectorGUI()
+	{
+		// Draw the default inspector fields
+		DrawDefaultInspector();
+
+		// Add a button
+		DialogueGroup group = (DialogueGroup)target;
+		if (GUILayout.Button("Update Groups"))
+		{
+			// Call the method when the button is clicked
+			group.LoadNodes();
+		}
+	}
+}

--- a/Assets/Scripts/Editor/Dialogue/DialogueGroupEditor.cs
+++ b/Assets/Scripts/Editor/Dialogue/DialogueGroupEditor.cs
@@ -6,14 +6,11 @@ public class DialogueGroupEditor : Editor
 {
 	public override void OnInspectorGUI()
 	{
-		// Draw the default inspector fields
 		DrawDefaultInspector();
 
-		// Add a button
 		DialogueGroup group = (DialogueGroup)target;
-		if (GUILayout.Button("Update Groups"))
+		if (GUILayout.Button("Update Nodes"))
 		{
-			// Call the method when the button is clicked
 			group.LoadNodes();
 		}
 	}

--- a/Assets/Scripts/Editor/Dialogue/DialogueGroupEditor.cs.meta
+++ b/Assets/Scripts/Editor/Dialogue/DialogueGroupEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 23002714a82ac5740b0d19216249e419

--- a/Assets/Scripts/Saving/Middleware/SavableComponent.cs
+++ b/Assets/Scripts/Saving/Middleware/SavableComponent.cs
@@ -30,7 +30,11 @@ public abstract class SavableComponent<TData> : MonoBehaviour, ISavable
 	/// <summary>
 	/// Gets a savable data assigned to this component.
 	/// </summary>
-	public TData data => _data;
+	public TData data
+	{
+		get => _data;
+		protected set => _data = value;
+	}
 
 	protected virtual void Awake()
 	{
@@ -56,9 +60,6 @@ public abstract class SavableComponent<TData> : MonoBehaviour, ISavable
 	/// A method that is called after loading and before saving
 	/// to ensure that data is valid. 
 	/// </summary>
-	/// <remarks>
-	/// When implemented, it must
-	/// </remarks>
 	/// <param name="data">
 	/// The data to validate, cannot be <see cref="null" />.
 	/// </param>
@@ -85,6 +86,7 @@ public abstract class SavableComponent<TData> : MonoBehaviour, ISavable
 
 		if (data is TData unboxedData)
 		{
+			Validate(unboxedData);
 			_data = unboxedData;
 		}
 		else
@@ -104,6 +106,7 @@ public abstract class SavableComponent<TData> : MonoBehaviour, ISavable
 	public object Save()
 	{
 		OnSave();
+		Validate(_data);
 		return _data;
 	}
 }


### PR DESCRIPTION
This pull request integrates the save system with the dialogues by adding the `DialogueActorSaver` component. If it's placed on top of the `DialogueActor`, its current node will be saved. The two requirements for this to work are:
1. A `DialogueGroup` assigned to the `DialogueActorSaver`. The dialogue groups are auto-filled with dialogue nodes that are placed in the same root directory.
2. A `SaveSystem` component that is present on the scene.