### PR TITLE
Implement Dialogue Conditions

### DIFF
--- a/Assets/Dialogues/Conditions.meta
+++ b/Assets/Dialogues/Conditions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb4a8f8299169a14a97d71e07b15b8f7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dialogues/Conditions/Dialogue50-50Condition.asset
+++ b/Assets/Dialogues/Conditions/Dialogue50-50Condition.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed571db98b717c74999a265613cc39bf, type: 3}
+  m_Name: Dialogue50-50Condition
+  m_EditorClassIdentifier: 
+  _probability: 0.5

--- a/Assets/Dialogues/Conditions/Dialogue50-50Condition.asset.meta
+++ b/Assets/Dialogues/Conditions/Dialogue50-50Condition.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9feb58cc2920f714987228ff73b52faf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dialogues/Test/TestDialogue1.asset
+++ b/Assets/Dialogues/Test/TestDialogue1.asset
@@ -63,7 +63,9 @@ MonoBehaviour:
       m_FallbackState: 0
       m_WaitForCompletion: 0
       m_LocalVariables: []
-    _nextNode: {fileID: 11400000, guid: 097dd3b1b240eba4f8e3390685398cfc, type: 2}
+    _branching:
+      _defaultNextNode: {fileID: 11400000, guid: 097dd3b1b240eba4f8e3390685398cfc, type: 2}
+      _branches: []
   - _text:
       m_TableReference:
         m_TableCollectionName: GUID:8600c5b7fc58eab4395a04b59313f353
@@ -73,11 +75,15 @@ MonoBehaviour:
       m_FallbackState: 0
       m_WaitForCompletion: 0
       m_LocalVariables: []
-    _nextNode: {fileID: 11400000, guid: 16348b85c526171458b8f2f26b3c8749, type: 2}
+    _branching:
+      _defaultNextNode: {fileID: 11400000, guid: 16348b85c526171458b8f2f26b3c8749, type: 2}
+      _branches: []
   _answerParams:
     _answerType: 2
     _timeToAnswer: 5
-  _nextNode: {fileID: 0}
+  _branching:
+    _defaultNextNode: {fileID: 0}
+    _branches: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Dialogues/Test/TestDialogue2-No.asset
+++ b/Assets/Dialogues/Test/TestDialogue2-No.asset
@@ -32,6 +32,7 @@ MonoBehaviour:
       m_FallbackState: 0
       m_WaitForCompletion: 0
     _duration: 2
+    _unskippable: 0
   - _speakerIndex: 1
     _text:
       m_TableReference:
@@ -51,8 +52,17 @@ MonoBehaviour:
       m_FallbackState: 0
       m_WaitForCompletion: 0
     _duration: 0
+    _unskippable: 0
   _options: []
-  _nextNode: {fileID: 11400000, guid: 479ccedc3cf7139409787b98714d6d95, type: 2}
+  _answerParams:
+    _answerType: 0
+    _timeToAnswer: 5
+  _branching:
+    _defaultNextNode: {fileID: 11400000, guid: 479ccedc3cf7139409787b98714d6d95, type: 2}
+    _branches:
+    - _node: {fileID: 11400000}
+      _conditions:
+      - {fileID: 11400000, guid: 9feb58cc2920f714987228ff73b52faf, type: 2}
   references:
     version: 2
     RefIds: []

--- a/Assets/Scripts/Dialogue/Data/Branching.meta
+++ b/Assets/Scripts/Dialogue/Data/Branching.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7a51405a23b5c244f80e6f574f2a4fa3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/Data/Branching/DialogueBranching.cs
+++ b/Assets/Scripts/Dialogue/Data/Branching/DialogueBranching.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Represents dialogue branching parameters.
+/// </summary>
+[Serializable]
+public class DialogueBranching
+{
+	/// <summary>
+	/// Represents a dialogue branch.
+	/// </summary>
+	[Serializable]
+	public class DialogueBranch
+	{
+		[SerializeField]
+		[Tooltip("A node assigned to the branch.")]
+		private DialogueNode _node;
+		[SerializeField]
+		[Tooltip("A list of conditions that must be satisfied in order for the " +
+			"node to be available.")]
+		private DialogueCondition[] _conditions;
+
+		/// <summary>
+		/// Gets a node assigned to the branch.
+		/// </summary>
+		public DialogueNode node => _node;
+		/// <summary>
+		/// Gets a readonly collection of conditions that must be satisfied
+		/// in order for the node to be available.
+		/// </summary>
+		public IReadOnlyList<DialogueCondition> conditions => _conditions;
+	}
+
+	[SerializeField]
+	[Tooltip("The next dialogue node that this option leads to if there " +
+		"are no available alternatives. Can be left empty.")]
+	private DialogueNode _defaultNextNode;
+
+	[SerializeField]
+	[Tooltip("A collection of all possible branches. Only the first one " +
+		"with all satisfied conditions is selected.")]
+	private DialogueBranch[] _branches;
+
+	/// <summary>
+	/// Gets the next dialogue node that this option leads to if there
+	/// are no available alternatives. Can be <see langword="null" />.
+	/// </summary>
+	public DialogueNode defaultNextNode => _defaultNextNode;
+
+	/// <summary>
+	/// Gets a readonly collection of all possible branches. Only the first one
+	/// with all satisfied conditions is selected.
+	/// </summary>
+	public IReadOnlyList<DialogueBranch> branches => _branches;
+}

--- a/Assets/Scripts/Dialogue/Data/Branching/DialogueBranching.cs
+++ b/Assets/Scripts/Dialogue/Data/Branching/DialogueBranching.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 /// <summary>
@@ -54,4 +55,30 @@ public class DialogueBranching
 	/// with all satisfied conditions is selected.
 	/// </summary>
 	public IReadOnlyList<DialogueBranch> branches => _branches;
+
+	/// <summary>
+	/// Selects the first available node.
+	/// </summary>
+	/// <returns>
+	/// The first available dialogue node from the <see cref="branches" /> or
+	/// the <see cref="defaultNextNode" />. Can be <see langword="null" />
+	/// </returns>
+	public DialogueNode SelectNode()
+	{
+		foreach (var branch in branches)
+		{
+			if (!branch.node)
+			{
+				Debug.LogWarning("A branch without valid node was detected.");
+				continue;
+			}
+
+			if (branch.conditions.All(x => x.IsSatisfiedFor(branch.node, this)))
+			{
+				return branch.node;
+			}
+		}
+
+		return _defaultNextNode;
+	}
 }

--- a/Assets/Scripts/Dialogue/Data/Branching/DialogueBranching.cs.meta
+++ b/Assets/Scripts/Dialogue/Data/Branching/DialogueBranching.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dadbeeead7d13a84da703d426dcc0e33

--- a/Assets/Scripts/Dialogue/Data/Conditions.meta
+++ b/Assets/Scripts/Dialogue/Data/Conditions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e406c4a40f0249c4f867f676046edf50
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/Data/Conditions/DialogueCondition.cs
+++ b/Assets/Scripts/Dialogue/Data/Conditions/DialogueCondition.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+/// <summary>
+/// Represents a condition of the dialogue node.
+/// </summary>
+public abstract class DialogueCondition : ScriptableObject
+{
+	/// <summary>
+	/// Checks whether the condition is satisfied for the specified
+	/// <paramref name="node"/> and <paramref name="actor"/>.
+	/// </summary>
+	/// <param name="node">A node to check against.</param>
+	/// <param name="branching">A branching hat contains this condition.</param>
+	/// <param name="actor">An actor that is related to the node.</param>
+	/// <returns>
+	/// <see langword="true" /> if this condition is satisfied;
+	/// otherwise <see langword="false" />.
+	/// </returns>
+	public abstract bool IsSatisfiedFor(DialogueNode node, DialogueBranching branching, DialogueActor actor);
+}

--- a/Assets/Scripts/Dialogue/Data/Conditions/DialogueCondition.cs
+++ b/Assets/Scripts/Dialogue/Data/Conditions/DialogueCondition.cs
@@ -11,10 +11,9 @@ public abstract class DialogueCondition : ScriptableObject
 	/// </summary>
 	/// <param name="node">A node to check against.</param>
 	/// <param name="branching">A branching hat contains this condition.</param>
-	/// <param name="actor">An actor that is related to the node.</param>
 	/// <returns>
 	/// <see langword="true" /> if this condition is satisfied;
 	/// otherwise <see langword="false" />.
 	/// </returns>
-	public abstract bool IsSatisfiedFor(DialogueNode node, DialogueBranching branching, DialogueActor actor);
+	public abstract bool IsSatisfiedFor(DialogueNode node, DialogueBranching branching);
 }

--- a/Assets/Scripts/Dialogue/Data/Conditions/DialogueCondition.cs.meta
+++ b/Assets/Scripts/Dialogue/Data/Conditions/DialogueCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 55144211038121247ad62b4e2800e9c8

--- a/Assets/Scripts/Dialogue/Data/Conditions/DialogueRandomCondition.cs
+++ b/Assets/Scripts/Dialogue/Data/Conditions/DialogueRandomCondition.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+/// <summary>
+/// A dialogue condition that has a probability to be satisfied.
+/// </summary>
+[CreateAssetMenu(fileName = "DialogueRandomCondition", menuName = "Dialogue/Conditions/Random")]
+public class DialogueRandomCondition : DialogueCondition
+{
+	[SerializeField]
+	[Tooltip("A probability of the condition to be satisfied.")]
+	private float _probability = 0.5f;
+
+	public override bool IsSatisfiedFor(DialogueNode node, DialogueBranching branching, DialogueActor actor)
+	{
+		return RandomUtils.Bool(_probability);
+	}
+}

--- a/Assets/Scripts/Dialogue/Data/Conditions/DialogueRandomCondition.cs
+++ b/Assets/Scripts/Dialogue/Data/Conditions/DialogueRandomCondition.cs
@@ -10,7 +10,7 @@ public class DialogueRandomCondition : DialogueCondition
 	[Tooltip("A probability of the condition to be satisfied.")]
 	private float _probability = 0.5f;
 
-	public override bool IsSatisfiedFor(DialogueNode node, DialogueBranching branching, DialogueActor actor)
+	public override bool IsSatisfiedFor(DialogueNode node, DialogueBranching branching)
 	{
 		return RandomUtils.Bool(_probability);
 	}

--- a/Assets/Scripts/Dialogue/Data/Conditions/DialogueRandomCondition.cs.meta
+++ b/Assets/Scripts/Dialogue/Data/Conditions/DialogueRandomCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ed571db98b717c74999a265613cc39bf

--- a/Assets/Scripts/Dialogue/Data/DialogueNode.cs
+++ b/Assets/Scripts/Dialogue/Data/DialogueNode.cs
@@ -28,10 +28,10 @@ public class DialogueNode : ScriptableObject
 
 	[Header("Branching")]
 	[SerializeField]
-	[Tooltip("A next node that is set as current after this started playing. " +
-		"If this node has options, this parameter will probably not do anything. " +
-		"Leave empty to set this node as the current.")]
-	private DialogueNode _nextNode;
+	[Tooltip("A branching that decides which node will be set as current after this node. " +
+		"If this node has at least one availble option, this parameter will be ignored. " +
+		"If branching fails, this node will remain the current.")]
+	private DialogueBranching _branching;
 
 	/// <summary>
 	/// Gets an ordered collection of phrases in the node.
@@ -48,9 +48,9 @@ public class DialogueNode : ScriptableObject
 	public DialogueAnswerParams answerParams => _answerParams;
 
 	/// <summary>
-	/// Gets a next node that is set as current after this started playing.
-	/// If this node has options, this parameter will probably not do anything. 
-	/// If <see langword="null"/>, this node will be set as the current."
+	/// A branching that decides which node will be set as current after this node.
+	/// If this node has at least one availble option, this parameter will be ignored.
+	/// If branching returns <see langword="null"/>, this node will remain the current.
 	/// </summary>
-	public DialogueNode nextNode => _nextNode;
+	public DialogueBranching branching => _branching;
 }

--- a/Assets/Scripts/Dialogue/Data/Options/DialogueOption.cs
+++ b/Assets/Scripts/Dialogue/Data/Options/DialogueOption.cs
@@ -13,15 +13,17 @@ public class DialogueOption
 		"May differ from the actual phrase.")]
 	private LocalizedString _text;
 	[SerializeField]
-	[Tooltip("The next dialogue node that this option leads to.")]
-	private DialogueNode _nextNode;
+	[Tooltip("Parameters that decide to which node this option leads. " +
+		"If no nodes are available in the branches, the option will not be visible.")]
+	private DialogueBranching _branching;
 
 	/// <summary>
 	/// Gets a short localized text description of the option.
 	/// </summary>
 	public LocalizedString text => _text;
 	/// <summary>
-	/// Gets the next dialogue node that this option leads to.
+	/// Gets the parameters that decide to which node this option leads.
+	/// If no nodes are available in the branches, the option will not be visible.
 	/// </summary>
-	public DialogueNode nextNode => _nextNode;
+	public DialogueBranching branching => _branching;
 }

--- a/Assets/Scripts/Dialogue/Player/DialoguePlayer.cs
+++ b/Assets/Scripts/Dialogue/Player/DialoguePlayer.cs
@@ -16,7 +16,13 @@ public class DialoguePlayer : MonoBehaviour
 	private DialogueNode _currentNode;
 	private readonly List<DialoguePreloadedPhrase> _preloadedPhrases = new();
 	private readonly List<string> _speakerNames = new();
-	private readonly List<string> _options = new();
+
+	// Texts for each option after converting to the current locale
+	private readonly List<string> _optionTexts = new();
+	// Available options of the current node
+	private readonly List<DialogueOption> _options = new();
+	// Nodes to which options are mapped
+	private readonly List<DialogueNode> _optionNodes = new();
 
 	private IDialogueListener _listener;
 	private bool _isPlaying = false;
@@ -70,7 +76,7 @@ public class DialoguePlayer : MonoBehaviour
 	{
 		_preloadedPhrases.Clear();
 		_speakerNames.Clear();
-		_options.Clear();
+		_optionTexts.Clear();
 
 		foreach (var speaker in _speakers)
 		{
@@ -97,11 +103,11 @@ public class DialoguePlayer : MonoBehaviour
 			_preloadedPhrases.Add(loadedPhrase);
 		}
 
-		foreach (var option in _currentNode.options)
+		foreach (var option in _options)
 		{
 			var optionAsyncOperation = option.text.GetLocalizedStringAsync();
 			yield return new WaitUntil(() => optionAsyncOperation.IsDone);
-			_options.Add(optionAsyncOperation.Result);
+			_optionTexts.Add(optionAsyncOperation.Result);
 		}
 	}
 
@@ -167,11 +173,11 @@ public class DialoguePlayer : MonoBehaviour
 			_listener.OnPhraseEnded(phraseContext);
 		}
 
-		if (_currentNode.options.Count > 0)
+		if (_options.Count > 0)
 		{
-			yield return new WaitUntil(() => _options.Count >= _currentNode.options.Count);
+			yield return new WaitUntil(() => _optionTexts.Count >= _options.Count);
 
-			DialogueOptionController.instance.RequestOption(_options,
+			DialogueOptionController.instance.RequestOption(_optionTexts,
 				_currentNode.answerParams, OnOptionSelected);
 		}
 		else
@@ -186,11 +192,12 @@ public class DialoguePlayer : MonoBehaviour
 
 	private void OnOptionSelected(int optionIndex)
 	{
-		var option = _currentNode.options[optionIndex];
+		var option = _options[optionIndex];
+		var nextNode = _optionNodes[optionIndex];
 
-		_listener.OnNodeEnded(_currentNode, option.nextNode);
+		_listener.OnNodeEnded(_currentNode, nextNode);
 
-		PlayNode(option.nextNode);
+		PlayNode(nextNode);
 
 		DialogueOptionContext context = new(_currentNode, option, optionIndex);
 		_listener.OnOptionChosen(context);
@@ -199,6 +206,19 @@ public class DialoguePlayer : MonoBehaviour
 	private void PlayNode(DialogueNode node)
 	{
 		_currentNode = node;
+		_options.Clear();
+		_optionNodes.Clear();
+
+		foreach (var option in node.options)
+		{
+			var optionNode = option.branching.SelectNode();
+			if (optionNode)
+			{
+				_options.Add(option);
+				_optionNodes.Add(optionNode);
+			}
+		}
+
 		StartCoroutine(PreloadPhrases());
 		StartCoroutine(PlayPhrases());
 	}

--- a/Assets/Scripts/Dialogue/Player/DialoguePlayer.cs
+++ b/Assets/Scripts/Dialogue/Player/DialoguePlayer.cs
@@ -176,7 +176,9 @@ public class DialoguePlayer : MonoBehaviour
 		}
 		else
 		{
-			DialogueNode next = _currentNode.nextNode ? _currentNode.nextNode : _currentNode;
+			DialogueNode next = _currentNode.branching.SelectNode();
+			if (!next) next = _currentNode;
+
 			_listener.OnNodeEnded(_currentNode, next);
 			End();
 		}


### PR DESCRIPTION
This pull request adds extended dialogue branching capabilities. Now options and next dialogue nodes can have alternative branches with their own conditions.

### Key Points

- The `DialogueBranching` parameters were added to replace the `nextNode` properites, both in the `DialogueOption` and the `DialogueNode`.
- The `DialogueCondition` abstract class was added. It defines a scriptable object that represents a dialogue branch condition.
- The `DialogueRandomCondition` was implemented. It's a dialogue condition that has a certain probability to be satisfied. Intended to be used mainly for testing purposes. It's currently used in the `TestDialogue2-No` as the `Dialogue50-50Condition`.