### PR TITLE
Dialogue Save Events

### DIFF
--- a/Assets/Dialogues/Test/SaveEvents.meta
+++ b/Assets/Dialogues/Test/SaveEvents.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 08c41f025ff8e0341b5d3758861dccb1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dialogues/Test/SaveEvents/TestDialogue2-NoWasChosen.asset
+++ b/Assets/Dialogues/Test/SaveEvents/TestDialogue2-NoWasChosen.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d5835be3654f3d4fb41c5b638c2fa86, type: 3}
+  m_Name: TestDialogue2-NoWasChosen
+  m_EditorClassIdentifier: 
+  _id: test_dialogue2_no_was_chosen

--- a/Assets/Dialogues/Test/SaveEvents/TestDialogue2-NoWasChosen.asset.meta
+++ b/Assets/Dialogues/Test/SaveEvents/TestDialogue2-NoWasChosen.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a0a0b43f7ff24b4d827676353c3f755
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dialogues/Test/SaveEvents/TestDialogue2-NoWasChosenCondition.asset
+++ b/Assets/Dialogues/Test/SaveEvents/TestDialogue2-NoWasChosenCondition.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 047d99fb0865100419395abaf5c313a4, type: 3}
+  m_Name: TestDialogue2-NoWasChosenCondition
+  m_EditorClassIdentifier: 
+  _targetState: 0
+  _event: {fileID: 11400000, guid: 6a0a0b43f7ff24b4d827676353c3f755, type: 2}

--- a/Assets/Dialogues/Test/SaveEvents/TestDialogue2-NoWasChosenCondition.asset.meta
+++ b/Assets/Dialogues/Test/SaveEvents/TestDialogue2-NoWasChosenCondition.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b471ac9eb14cd1749a696d0e95a430db
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dialogues/Test/TestDialogue1.asset
+++ b/Assets/Dialogues/Test/TestDialogue1.asset
@@ -64,8 +64,11 @@ MonoBehaviour:
       m_WaitForCompletion: 0
       m_LocalVariables: []
     _branching:
-      _defaultNextNode: {fileID: 11400000, guid: 097dd3b1b240eba4f8e3390685398cfc, type: 2}
-      _branches: []
+      _defaultNextNode: {fileID: 0}
+      _branches:
+      - _node: {fileID: 11400000, guid: 097dd3b1b240eba4f8e3390685398cfc, type: 2}
+        _conditions:
+        - {fileID: 11400000, guid: b471ac9eb14cd1749a696d0e95a430db, type: 2}
   - _text:
       m_TableReference:
         m_TableCollectionName: GUID:8600c5b7fc58eab4395a04b59313f353

--- a/Assets/Dialogues/Test/TestDialogue2-No.asset
+++ b/Assets/Dialogues/Test/TestDialogue2-No.asset
@@ -59,10 +59,7 @@ MonoBehaviour:
     _timeToAnswer: 5
   _branching:
     _defaultNextNode: {fileID: 11400000, guid: 479ccedc3cf7139409787b98714d6d95, type: 2}
-    _branches:
-    - _node: {fileID: 11400000}
-      _conditions:
-      - {fileID: 11400000, guid: 9feb58cc2920f714987228ff73b52faf, type: 2}
+    _branches: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Prefabs/Functionality/SaveSystem.prefab
+++ b/Assets/Prefabs/Functionality/SaveSystem.prefab
@@ -1,5 +1,63 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4171464418760894400
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4017110804406858821}
+  - component: {fileID: 2438274519865527452}
+  - component: {fileID: 1705276124827892469}
+  m_Layer: 0
+  m_Name: DialogueEvents
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4017110804406858821
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4171464418760894400}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3855088386138911170}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2438274519865527452
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4171464418760894400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7b5ed8af42dbbc747af80b420a82fe15, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _id: dialogue_events
+--- !u!114 &1705276124827892469
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4171464418760894400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14eddc7644cf1a94ca1e787acd6c230a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &5462522973888765915
 GameObject:
   m_ObjectHideFlags: 0
@@ -30,7 +88,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 4017110804406858821}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7366256545132032932
@@ -57,3 +116,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6174def807d09b34bbfd32870c9a9192, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _developmentSlotName: dev

--- a/Assets/Scenes/Development/DialoguesTest.unity
+++ b/Assets/Scenes/Development/DialoguesTest.unity
@@ -881,6 +881,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1302503604}
   - component: {fileID: 1302503605}
+  - component: {fileID: 1302503606}
   m_Layer: 0
   m_Name: TestDialogue2-No
   m_TagString: Untagged
@@ -931,6 +932,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
+      - m_Target: {fileID: 1302503606}
+        m_TargetAssemblyTypeName: DialogueSaveEventAction, Assembly-CSharp
+        m_MethodName: Perform
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
   _ended:
     m_PersistentCalls:
       m_Calls:
@@ -947,6 +960,20 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
   _phraseIndex: 1
+--- !u!114 &1302503606
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1302503603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 610f8eff18c7e5d40ad3e2d5f6d4632e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _event: {fileID: 11400000, guid: 6a0a0b43f7ff24b4d827676353c3f755, type: 2}
+  _action: 0
 --- !u!1 &1439296357
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Dialogue/Data/Conditions/DialogueSaveEventCondition.cs
+++ b/Assets/Scripts/Dialogue/Data/Conditions/DialogueSaveEventCondition.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 /// <summary>
 /// An dialogue event that checks the save event key.
 /// </summary>
+[CreateAssetMenu(fileName = "DialogueRandomCondition", menuName = "Dialogue/Conditions/Save Event")]
 public class DialogueSaveEventCondition : DialogueCondition
 {
 	public enum DialogueEventState

--- a/Assets/Scripts/Dialogue/Data/Conditions/DialogueSaveEventCondition.cs
+++ b/Assets/Scripts/Dialogue/Data/Conditions/DialogueSaveEventCondition.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+/// <summary>
+/// An dialogue event that checks the save event key.
+/// </summary>
+public class DialogueSaveEventCondition : DialogueCondition
+{
+	public enum DialogueEventState
+	{
+		Exists,
+		NotExists
+	}
+
+	[SerializeField]
+	[Tooltip("A target state of the event key that satisfies the condition. " +
+		"'Exists' means that the event was added and 'NotExists' means that " +
+		"the event was removed or not triggered.")]
+	private DialogueEventState _targetState;
+	[SerializeField]
+	[Tooltip("An event that is checked in this condition.")]
+	private DialogueSaveEvent _event;
+
+	private DialogueEventState GetState()
+	{
+		return DialogueSaveEventsProvider.instance.ContainsKey(_event.id) ?
+			DialogueEventState.Exists : DialogueEventState.NotExists;
+	}
+
+	public override bool IsSatisfiedFor(DialogueNode node, DialogueBranching branching)
+	{
+		return GetState() == _targetState;
+	}
+}

--- a/Assets/Scripts/Dialogue/Data/Conditions/DialogueSaveEventCondition.cs
+++ b/Assets/Scripts/Dialogue/Data/Conditions/DialogueSaveEventCondition.cs
@@ -28,6 +28,13 @@ public class DialogueSaveEventCondition : DialogueCondition
 
 	public override bool IsSatisfiedFor(DialogueNode node, DialogueBranching branching)
 	{
+		if (!_event)
+		{
+			Debug.LogError($"The dialogue event condition \"{name}\" " +
+				$"has no dialogue event assigned to it.", this);
+			return false;
+		}
+
 		return GetState() == _targetState;
 	}
 }

--- a/Assets/Scripts/Dialogue/Data/Conditions/DialogueSaveEventCondition.cs.meta
+++ b/Assets/Scripts/Dialogue/Data/Conditions/DialogueSaveEventCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 047d99fb0865100419395abaf5c313a4

--- a/Assets/Scripts/Dialogue/Saving/Events.meta
+++ b/Assets/Scripts/Dialogue/Saving/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10e78e9a797a7cb4eaaaa8583002f04e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/Saving/Events/DialogueEventsSaveData.cs
+++ b/Assets/Scripts/Dialogue/Saving/Events/DialogueEventsSaveData.cs
@@ -1,0 +1,13 @@
+using System;
+
+/// <summary>
+/// Data structure that stores saved dialogue event keys.
+/// </summary>
+[Serializable]
+public class DialogueEventsSaveData
+{
+	/// <summary>
+	/// Gets/sets all event keys that were saved.
+	/// </summary>
+	public string[] keys { get; set; }
+}

--- a/Assets/Scripts/Dialogue/Saving/Events/DialogueEventsSaveData.cs.meta
+++ b/Assets/Scripts/Dialogue/Saving/Events/DialogueEventsSaveData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8bfbe014009b60d4c9c37e8666fadd1c

--- a/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEvent.cs
+++ b/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEvent.cs
@@ -8,7 +8,7 @@ public class DialogueSaveEvent : ScriptableObject
 	private string _id = "dialogue_event";
 
 	/// <summary>
-	/// Gets the unique identifier of the event
+	/// Gets the unique identifier of the event.
 	/// </summary>
 	public string id => _id;
 }

--- a/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEvent.cs
+++ b/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEvent.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "DialogueNode", menuName = "Dialogue/Save Event")]
+public class DialogueSaveEvent : ScriptableObject
+{
+	[SerializeField]
+	[Tooltip("A unique identifier of the event.")]
+	private string _id = "dialogue_event";
+
+	/// <summary>
+	/// Gets the unique identifier of the event
+	/// </summary>
+	public string id => _id;
+}

--- a/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEvent.cs.meta
+++ b/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEvent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2d5835be3654f3d4fb41c5b638c2fa86

--- a/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventAction.cs
+++ b/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventAction.cs
@@ -1,0 +1,50 @@
+using UnityEngine;
+
+/// <summary>
+/// A component that represents a save event action. It's intended to 
+/// be used together with the <see cref="DialogueNodeTrigger"/> in 
+/// the Unity events.
+/// </summary>
+public class DialogueSaveEventAction : MonoBehaviour
+{
+	public enum EventAction
+	{
+		Add,
+		Remove
+	}
+
+	[SerializeField]
+	[Tooltip("An event on which the action is performed.")]
+	private DialogueSaveEvent _event;
+
+	[SerializeField]
+	[Tooltip("An action that is performed on the save event.")]
+	private EventAction _action = EventAction.Add;
+
+	/// <summary>
+	/// Performs the action.
+	/// </summary>
+	public void Perform()
+	{
+		if (!_event)
+		{
+			Debug.LogError($"The dialogue save event action (\"{gameObject.name}\") " +
+				$"has no dialogue event assigned to it.", gameObject);
+			return;
+		}
+
+		switch (_action)
+		{
+			case EventAction.Add:
+				DialogueSaveEventsProvider.instance.AddKey(_event.id);
+				break;
+			case EventAction.Remove:
+				DialogueSaveEventsProvider.instance.RemoveKey(_event.id);
+				break;
+
+			default:
+				Debug.Log($"Invalid event action: {(int)_action}.", gameObject);
+				break;
+		}
+	}
+}

--- a/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventAction.cs.meta
+++ b/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventAction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 610f8eff18c7e5d40ad3e2d5f6d4632e

--- a/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventsProvider.cs
+++ b/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventsProvider.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+
+/// <summary>
+/// A singleton that provides dialogue save event keys.
+/// </summary>
+[RequireComponent(typeof(DialogueSaveEventsStorage))]
+public sealed class DialogueSaveEventsProvider : SingletonMonoBehaviour<DialogueSaveEventsProvider>
+{
+	private DialogueSaveEventsStorage _storage;
+
+	protected override void Awake()
+	{
+		base.Awake();
+
+		_storage = GetComponent<DialogueSaveEventsStorage>();
+	}
+
+	/// <summary>
+	/// Checks whether the key exists.
+	/// </summary>
+	/// <param name="key">The key which is checked for existance.</param>
+	/// <returns>
+	/// <see langword="true" /> if the <paramref name="key"/> exists,
+	/// otherwise <see langword="false" />.
+	/// </returns>
+	/// <exception cref="System.ArgumentNullException" />
+	public bool ContainsKey(string key)
+	{
+		if (key == null)
+			throw new System.ArgumentNullException(nameof(key));
+
+		return _storage.keys.Contains(key);
+	}
+
+	/// <summary>
+	/// Adds the dialogue event save key.
+	/// </summary>
+	/// <param name="key">A key to be added.</param>
+	/// <exception cref="System.ArgumentNullException" />
+	public void AddKey(string key)
+	{
+		if (key == null)
+			throw new System.ArgumentNullException(nameof(key));
+
+		_storage.keys.Add(key);
+	}
+
+	/// <summary>
+	/// Removes the dialogue event save key.
+	/// </summary>
+	/// <remarks>
+	/// Does nothing if the key doesn't exist.
+	/// </remarks>
+	/// <param name="key">A key to be removed.</param>
+	/// <exception cref="System.ArgumentNullException" />
+	public void RemoveKey(string key)
+	{
+		if (key == null)
+			throw new System.ArgumentNullException(nameof(key));
+
+		_storage.keys.Remove(key);
+	}
+}

--- a/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventsProvider.cs.meta
+++ b/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventsProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 14eddc7644cf1a94ca1e787acd6c230a

--- a/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventsStorage.cs
+++ b/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventsStorage.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,14 +7,19 @@ using System.Linq;
 /// </summary>
 public class DialogueSaveEventsStorage : SavableComponent<DialogueEventsSaveData>
 {
+	protected override DialogueEventsSaveData fallbackData => new()
+	{
+		keys = Array.Empty<string>()
+	};
+
 	/// <summary>
 	/// Gets a hash set containing dialogue save event keys.
 	/// </summary>
-	public HashSet<string> keys { get; private set; }
+	public HashSet<string> keys { get; private set; } = new();
 
 	protected override void OnLoad()
 	{
-		keys = new(data.keys);
+		keys = new(data.keys ?? Array.Empty<string>());
 	}
 
 	protected override void OnSave()

--- a/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventsStorage.cs
+++ b/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventsStorage.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// A component that stores dialogue save event keys.
+/// </summary>
+public class DialogueSaveEventsStorage : SavableComponent<DialogueEventsSaveData>
+{
+	/// <summary>
+	/// Gets a hash set containing dialogue save event keys.
+	/// </summary>
+	public HashSet<string> keys { get; private set; }
+
+	protected override void OnLoad()
+	{
+		keys = new(data.keys);
+	}
+
+	protected override void OnSave()
+	{
+		data.keys = keys.ToArray();
+	}
+}

--- a/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventsStorage.cs.meta
+++ b/Assets/Scripts/Dialogue/Saving/Events/DialogueSaveEventsStorage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7b5ed8af42dbbc747af80b420a82fe15


### PR DESCRIPTION
This pull request adds dialogue save events system that allows to save player choices and show different branching options for different choices.

### Testing

Now, the test speaker doesn't have the "Yes" option if the "No" option has not been chosen before.
