### PR TITLE
Shared Dialogue Groups Saving

### DIFF
--- a/Assets/Dialogues/Shared/SharedDialogueGroup.asset
+++ b/Assets/Dialogues/Shared/SharedDialogueGroup.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c344bf28d4ddb634ea370fb8edc56ffc, type: 3}
+  m_Name: SharedDialogueGroup
+  m_EditorClassIdentifier: 
+  _children:
+  - {fileID: 11400000, guid: 5c0f89d7655a07c47bed42e69a630cd1, type: 2}

--- a/Assets/Dialogues/Shared/SharedDialogueGroup.asset.meta
+++ b/Assets/Dialogues/Shared/SharedDialogueGroup.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82bc62c8d82f41e48bc4104ae23dd644
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 6756243041131944203}
   - component: {fileID: 2542461234868552012}
   m_Layer: 3
-  m_Name: Speaker
+  m_Name: PlayerSpeaker
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -26,12 +26,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 513648519354914691}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 7119086467292122724}
+  m_Father: {fileID: 4318253877659320643}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!82 &6756243041131944203
 AudioSource:
@@ -154,6 +154,52 @@ MonoBehaviour:
   references:
     version: 2
     RefIds: []
+--- !u!1 &636055615753314097
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4318253877659320643}
+  - component: {fileID: 6798547604962947115}
+  m_Layer: 3
+  m_Name: Dialogue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4318253877659320643
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 636055615753314097}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9049308865856208928}
+  m_Father: {fileID: 7119086467292122724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6798547604962947115
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 636055615753314097}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c624a2afa674d842b40ec73e4afc60e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _sharedGroup: {fileID: 11400000, guid: 82bc62c8d82f41e48bc4104ae23dd644, type: 2}
 --- !u!1 &1014059809471077422
 GameObject:
   m_ObjectHideFlags: 0
@@ -1067,7 +1113,7 @@ Transform:
   - {fileID: 7231063628934557969}
   - {fileID: 5957870956636181333}
   - {fileID: 2682713552509663914}
-  - {fileID: 9049308865856208928}
+  - {fileID: 4318253877659320643}
   - {fileID: 3974216078320560098}
   - {fileID: 1410108630627435345}
   m_Father: {fileID: 0}

--- a/Assets/Scripts/Data/SharedDialogueGroupProvider.cs
+++ b/Assets/Scripts/Data/SharedDialogueGroupProvider.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+/// <summary>
+/// A component that provides a default shared dialogue group.
+/// </summary>
+public class SharedDialogueGroupProvider : SingletonMonoBehaviour<SharedDialogueGroupProvider>
+{
+	[SerializeField]
+	private DialogueGroup _sharedGroup;
+
+	/// <summary>
+	/// Gets the shared group.
+	/// </summary>
+	public DialogueGroup sharedGroup => _sharedGroup;
+}

--- a/Assets/Scripts/Data/SharedDialogueGroupProvider.cs
+++ b/Assets/Scripts/Data/SharedDialogueGroupProvider.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 /// <summary>
 /// A component that provides a default shared dialogue group.
 /// </summary>
-public class SharedDialogueGroupProvider : SingletonMonoBehaviour<SharedDialogueGroupProvider>
+public sealed class SharedDialogueGroupProvider : SingletonMonoBehaviour<SharedDialogueGroupProvider>
 {
 	[SerializeField]
 	private DialogueGroup _sharedGroup;

--- a/Assets/Scripts/Data/SharedDialogueGroupProvider.cs.meta
+++ b/Assets/Scripts/Data/SharedDialogueGroupProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c624a2afa674d842b40ec73e4afc60e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: -500
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/Player/Speakers/DialogueSpeaker.cs.meta
+++ b/Assets/Scripts/Dialogue/Player/Speakers/DialogueSpeaker.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 12ac9724153a36e43a829e944361034c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 300
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/Saving/DialogueActorSaver.cs
+++ b/Assets/Scripts/Dialogue/Saving/DialogueActorSaver.cs
@@ -7,6 +7,8 @@ using UnityEngine;
 [RequireComponent(typeof(DialogueActor))]
 public class DialogueActorSaver : SavableComponent<DialogueSaveData>
 {
+	private DialogueGroup _sharedGroup;
+
 	private DialogueActor _actor;
 	private DialogueActor actor => _actor ? _actor : _actor = GetComponent<DialogueActor>();
 
@@ -16,11 +18,21 @@ public class DialogueActorSaver : SavableComponent<DialogueSaveData>
 
 	protected override DialogueSaveData fallbackData => new();
 
+	protected override void Awake()
+	{
+		_sharedGroup = SharedDialogueGroupProvider.exists ?
+			SharedDialogueGroupProvider.instance.sharedGroup : null;
+
+		base.Awake();
+	}
+
 	protected override void Validate(DialogueSaveData data)
 	{
 		if (string.IsNullOrEmpty(data.nextNodeName) || !_group) return;
 
-		if (!_group.nameToObject.ContainsKey(data.nextNodeName))
+		if (!_group.nameToObject.ContainsKey(data.nextNodeName) &&
+			(!_sharedGroup || !_sharedGroup.nameToObject.ContainsKey(data.nextNodeName))
+			)
 		{
 			Debug.LogWarning($"Couldn't find a dialogue node with \"{data.nextNodeName}\" name.", gameObject);
 			data.nextNodeName = null;
@@ -36,7 +48,9 @@ public class DialogueActorSaver : SavableComponent<DialogueSaveData>
 		}
 
 		if (!string.IsNullOrEmpty(data.nextNodeName) &&
-			_group.nameToObject.TryGetValue(data.nextNodeName, out var node))
+			(_group.nameToObject.TryGetValue(data.nextNodeName, out var node) ||
+			_sharedGroup && _sharedGroup.nameToObject.TryGetValue(data.nextNodeName, out node))
+			)
 		{
 			actor.SetNextNode(node);
 		}


### PR DESCRIPTION
This pull request allows save system to see the dialogue nodes from the `Assets/Dialogues/Shared` for any dialogue actor.

### Key changes
- The `SharedDialogueGroupProvider` singleton was added. It provides the shared dialogue group that can be used for all dialogue actors. It's assigned to the `Player` prefab.
- The `DialogueActorSaver` was modified to be able to use the shared dialogue group.
- The `SharedDialogueGroup` was added in the `Assets/Dialogues/Shared` folder.