### PR TITLE
Improve subtitles ux

### DIFF
--- a/Assets/Prefabs/UI/Dialogues/Subtitles.prefab
+++ b/Assets/Prefabs/UI/Dialogues/Subtitles.prefab
@@ -150,7 +150,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 2
+  m_HorizontalAlignment: 1
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0

--- a/Assets/Scripts/Dialogue/Player/DialoguePlayer.cs
+++ b/Assets/Scripts/Dialogue/Player/DialoguePlayer.cs
@@ -146,10 +146,17 @@ public class DialoguePlayer : MonoBehaviour
 			subtitle, duration, SubtitlePriority.Dialogue, speakerName);
 	}
 
-	private void CancelPhrase(DialoguePhrase phrase)
+	private bool CancelPhrase(DialoguePhrase phrase)
 	{
+		if (_currentSubtitlesDisplayer.isTyping)
+		{
+			_currentSubtitlesDisplayer.SkipTyping();
+			return false;
+		}
 		_speakers[phrase.speakerIndex].Stop();
 		_currentSubtitlesDisplayer.Cancel();
+
+		return true;
 	}
 
 	private bool IsSkipped(DialoguePhrase phrase)
@@ -195,8 +202,10 @@ public class DialoguePlayer : MonoBehaviour
 			{
 				if (t >= phraseSkipDelay && IsSkipped(phrase))
 				{
-					CancelPhrase(phrase);
-					break;
+					if (CancelPhrase(phrase))
+					{
+						break;
+					}
 				}
 				_skipPhrase = false;
 


### PR DESCRIPTION
This pull request improves the subtitles UX:

- The end screen subtitles now are aligned to the left, making reading them during the typing animation easier.
- Any button press now skips the typing animation before skipping the dialogue line.