### PR TITLE
Hour range trigger

### DIFF
--- a/Assets/Scripts/Time/Clock.cs
+++ b/Assets/Scripts/Time/Clock.cs
@@ -11,6 +11,9 @@ public class Clock : SingletonMonoBehaviour<Clock>
 	[SerializeField]
 	[Tooltip("How many minutes player is given at the start.")]
 	private int _minutesAtStart = 60 * 24;
+	[SerializeField]
+	[Tooltip("Time when the game starts.")]
+	private int _startTimeMinutes = 7 * 60;
 
 	/// <summary>
 	/// Gets/sets a number of minutes left.
@@ -37,6 +40,10 @@ public class Clock : SingletonMonoBehaviour<Clock>
 			}
 		}
 	}
+	/// <summary>
+	/// Gets the time in minutes when the game starts.
+	/// </summary>
+	public int startTimeMinutes => _startTimeMinutes;
 
 	/// <summary>
 	/// Gets a number of minutes that player is given at the start.

--- a/Assets/Scripts/Time/Control/HourRangeTrigger.cs
+++ b/Assets/Scripts/Time/Control/HourRangeTrigger.cs
@@ -5,15 +5,21 @@ using UnityEngine.Events;
 /// A component that triggers the event when the time left is in
 /// a specific range.
 /// </summary>
-[System.Obsolete("Use HourRangeTrigger instead.")]
-public class TimeRangeTrigger : Trigger
+public class HourRangeTrigger : Trigger
 {
+	private enum TriggerWhen
+	{
+		InRange, OutRange
+	}
+
 	private bool _wasTriggered = false;
 
-	[SerializeField, Min(0)]
-	private int _minMinutesLeft;
-	[SerializeField, Min(0)]
-	private int _maxMinutesLeft;
+	[SerializeField, Min(0f)]
+	private float _from = 7f;
+	[SerializeField, Min(0f)]
+	private float _to = 8.5f;
+	[SerializeField]
+	private TriggerWhen _triggerWhen;
 	[SerializeField]
 	private UnityEvent _triggered;
 
@@ -28,7 +34,7 @@ public class TimeRangeTrigger : Trigger
 
 	private void OnValidate()
 	{
-		_maxMinutesLeft = Mathf.Max(_maxMinutesLeft, _minMinutesLeft);
+		_to = Mathf.Max(_to, _from);
 	}
 
 	private void OnTimeUpdated(Clock clock)
@@ -40,11 +46,17 @@ public class TimeRangeTrigger : Trigger
 	{
 		if (_wasTriggered) return;
 
-		if (Clock.instance.minutesLeft >= _minMinutesLeft &&
-			Clock.instance.minutesLeft <= _maxMinutesLeft)
+		Clock clock = Clock.instance;
+		int currentMinutes = clock.minutesAtStart - clock.minutesLeft + clock.startTimeMinutes;
+		float currentHour = currentMinutes / 60f;
+
+		bool condition = currentHour >= _from && currentHour <= _to;
+		if (_triggerWhen == TriggerWhen.OutRange)
+			condition = !condition;
+
+		if (condition)
 		{
 			_wasTriggered = true;
-
 			_triggered.Invoke();
 			InvokeTriggered();
 		}

--- a/Assets/Scripts/Time/Control/HourRangeTrigger.cs.meta
+++ b/Assets/Scripts/Time/Control/HourRangeTrigger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e487d581a5a04a446925c0e0d2a8f35c

--- a/Assets/Scripts/UI/ClockDisplayer.cs
+++ b/Assets/Scripts/UI/ClockDisplayer.cs
@@ -11,9 +11,6 @@ public class ClockDisplayer : MonoBehaviour
 	[SerializeField]
 	private TMP_Text _label;
 
-	[SerializeField, Min(0)]
-	private int _startTimeMinutes = 7 * 60;
-
 	private void Start()
 	{
 		if (Clock.exists)
@@ -27,7 +24,7 @@ public class ClockDisplayer : MonoBehaviour
 
 	private void UpdateTime()
 	{
-		int totalMinutes = _clock.minutesAtStart - _clock.minutesLeft + _startTimeMinutes;
+		int totalMinutes = _clock.minutesAtStart - _clock.minutesLeft + _clock.startTimeMinutes;
 
 		int hours = totalMinutes / 60;
 		int minutes = totalMinutes % 60;

--- a/Docs/GameDesignerCookbook.md
+++ b/Docs/GameDesignerCookbook.md
@@ -66,7 +66,7 @@
 
 The game counts time in minutes. The starting number of minutes can be edited inside the `Player` prefab (use the `t:Prefab Player` search prompt in the Project window):
 
-![image](https://github.com/user-attachments/assets/18815167-e4c5-4a8d-9328-9607cbd82827)
+![image](https://github.com/user-attachments/assets/0dcf20d3-6208-49fc-8595-2676fab78df8)
 
 Minutes can be spent using the `SpendTimeAction` which can be triggered by dialogues or quests.
 

--- a/Docs/GameDesignerCookbook.md
+++ b/Docs/GameDesignerCookbook.md
@@ -502,4 +502,5 @@ To combine triggers with actions, just add both trigger and action to your game 
     Can be chained.
 5. `SubquestStateTrigger` - same as the `QuestStateTrigger` but for the subquests. Can be chained.
 6. `TimeOverTrigger` - a trigger that calls the event after the [time is over](#clock). Additionally, the "Initial State Check" flag defines whether the trigger should call the event if the game has started with 0 minutes left. Can be chained.
-7. `TimeRangeTrigger` - a trigger that calls the event when the [minutes left](#clock) value is in within the range from "Min Minutes Left" (inclusive) to "Max Minutes Left" (inclusive). This event is called only once.
+7. ~~`TimeRangeTrigger`~~ (obsolete, use `HourRangeTrigger` instead) - a trigger that calls the event when the [minutes left](#clock) value is in within the range from "Min Minutes Left" (inclusive) to "Max Minutes Left" (inclusive). This event is called only once.
+8. `HourRangeTrigger` - a trigger that calls the event when the current hour is in within the range "From" - "To". In the "Triggered When", if the "Out Range" option is selected the trigger will call event if the current hour is outside of the range. This event is called only once.


### PR DESCRIPTION
This pull request adds the `HourRangeTrigger` that is meant to replace the `TimeRangeTrigger`. Compared to the `TimeRangeTrigger`, the `HouseRangeTrigger` is more convenient to use because you can directly set hours instead of converting them to minutes manually.